### PR TITLE
Update riemann-clojure-client and send-event function name

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [riemann-clojure-client "0.2.9"]
+                 [riemann-clojure-client "0.3.2"]
                  [environ "0.4.0"]])

--- a/src/datomic_riemann_reporter.clj
+++ b/src/datomic_riemann_reporter.clj
@@ -24,7 +24,7 @@
 
 (defn send-event [event]
   (if-let [actual-client (client)]
-    (riemann/async-send-event
+    (riemann/send-event
       actual-client
       (merge event
              {:tags (add-additional-environment-tags ["datomic"])}))


### PR DESCRIPTION
In latest riemann-clojure-client, async-send-event is renamed to send-event.
